### PR TITLE
MultipleRawFileOutputFormat: support multiple raw files without typedbytes wrapping

### DIFF
--- a/src/output/MultipleRawFileOutputFormat.java
+++ b/src/output/MultipleRawFileOutputFormat.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fm.last.feathers.output;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.mapred.lib.MultipleOutputFormat;
+import org.apache.hadoop.util.Progressable;
+
+import fm.last.feathers.output.RawFileOutputFormat;
+
+/**
+ * This class extends the MultipleOutputFormat, allowing to write the output data-
+ * to different output files in raw file output format.
+ */
+public class MultipleRawFileOutputFormat <K,V>
+extends MultipleOutputFormat<K, V> {
+
+    private RawFileOutputFormat<K,V> theRawFileOutputFormat = null;
+
+    @Override
+    protected RecordWriter<K, V> getBaseRecordWriter(FileSystem fs,
+                                                   JobConf job,
+                                                   String name,
+                                                   Progressable arg3)
+    throws IOException {
+        if (theRawFileOutputFormat == null) {
+            theRawFileOutputFormat = new RawFileOutputFormat<K,V>();
+        }
+        return theRawFileOutputFormat.getRecordWriter(fs, job, name, arg3);
+    }
+
+  protected String generateFileNameForKeyValue(K key, V value, String name) {
+    return new Path(key.toString(), name).toString() ;
+  }
+
+}
+


### PR DESCRIPTION
Hello,

this fork extend RawFileOutputFormat and support generating multiple raw outputs based on keys.

MultipleRawFileOutputFormat and RawFileOutputFormat are the base for a dumbo change that adds RawReducer and MultiRawReducer that will easy the generation of raw files from dumbo reducers. The two working examples I have right now are TokyoCabinets and Google visualization datatables. I will get them in form before requesting a pulling from dumbo.

thanks.
Daniel
