### PR TITLE
MultipleRawFileOutputFormat: new option to strip part-nnnnn from output name

### DIFF
--- a/src/output/MultipleRawFileOutputFormat.java
+++ b/src/output/MultipleRawFileOutputFormat.java
@@ -35,25 +35,23 @@ import fm.last.feathers.output.RawFileOutputFormat;
  * to different output files in raw file output format.
  */
 public class MultipleRawFileOutputFormat <K,V>
-extends MultipleOutputFormat<K, V> {
+  extends MultipleOutputFormat<K, V> {
 
-    private RawFileOutputFormat<K,V> theRawFileOutputFormat = null;
+  private RawFileOutputFormat<K,V> theRawFileOutputFormat = null;
 
-    @Override
-    protected RecordWriter<K, V> getBaseRecordWriter(FileSystem fs,
+  @Override
+  protected RecordWriter<K, V> getBaseRecordWriter(FileSystem fs,
                                                    JobConf job,
                                                    String name,
                                                    Progressable arg3)
-    throws IOException {
-        if (theRawFileOutputFormat == null) {
-            theRawFileOutputFormat = new RawFileOutputFormat<K,V>();
-        }
-        return theRawFileOutputFormat.getRecordWriter(fs, job, name, arg3);
-    }
-
-  protected String generateFileNameForKeyValue(K key, V value, String name) {
-    return new Path(key.toString(), name).toString() ;
+  throws IOException {
+    if (this.theRawFileOutputFormat == null)
+      this.theRawFileOutputFormat = new RawFileOutputFormat<K, V>();
+    return this.theRawFileOutputFormat.getRecordWriter(fs, job, name, arg3);
   }
 
+  @Override
+  protected String generateFileNameForKeyValue(K key, V value, String name) {
+    return new Path(key.toString(), name).toString();
+  }
 }
-

--- a/src/output/MultipleRawFileOutputFormat.java
+++ b/src/output/MultipleRawFileOutputFormat.java
@@ -54,4 +54,11 @@ public class MultipleRawFileOutputFormat <K,V>
   protected String generateFileNameForKeyValue(K key, V value, String name) {
     return new Path(key.toString(), name).toString();
   }
+
+  @Override
+  protected String getInputFileBasedOutputFileName(JobConf job, String name) {
+    if (job.getBoolean("feathers.output.filename.strippart", false))
+      name = new Path(name).getParent().toString();
+    return super.getInputFileBasedOutputFileName(job, name);
+  }
 }


### PR DESCRIPTION
Adds support to strip part-nnnnn from output filenames trough a jobconf option named `feathers.output.filename.strippart` and turned off by default. Also includes style indentation fixes and adds missing @Override annotations.
